### PR TITLE
Add and implement IModSource.Initialize

### DIFF
--- a/src/Alpacka.Lib/Curse/ModSourceCurse.cs
+++ b/src/Alpacka.Lib/Curse/ModSourceCurse.cs
@@ -16,13 +16,18 @@ namespace Alpacka.Lib.Curse
         private static readonly ConcurrentDictionary<EntryMod, DependencyType> _modToDependencyType =
             new ConcurrentDictionary<EntryMod, DependencyType>();
             
-        private Lazy<Task<ProjectList>> AllProjects { get; } = new Lazy<Task<ProjectList>>(LatestProjects.Get);
+        private ProjectList _allProjects;
         
         public bool CanHandle(string source) =>
             (source.StartsWith("curse:") || !source.Contains(":"));
         
-        public async Task<string> Resolve(EntryMod mod, string mcVersion, Action<EntryMod> addDependency) {
-            var allProjects = await AllProjects.Value;
+        public async Task Initialize()
+        {
+            _allProjects = await LatestProjects.Get();
+        }
+        
+        public async Task<string> Resolve(EntryMod mod, string mcVersion, Action<EntryMod> addDependency)
+        {
             var id = -1;
             var splitSource = mod.Source.Split(new char[]{ ':' }, 2);
             var source = splitSource[splitSource.Length-1].Trim();
@@ -35,7 +40,7 @@ namespace Alpacka.Lib.Curse
             
             Addon addon;
             if (!int.TryParse(source, out id)) {
-                addon = allProjects.Data.Find(a => string.Equals(a.Name.Trim(), source, StringComparison.OrdinalIgnoreCase));
+                addon = _allProjects.Data.Find(a => string.Equals(a.Name.Trim(), source, StringComparison.OrdinalIgnoreCase));
                 if (addon == null)
                     throw new Exception($"No Project of name '{ source }' found");
                 // Debug.WriteLine(_addon.ToPrettyJson());

--- a/src/Alpacka.Lib/Mods/IModSource.cs
+++ b/src/Alpacka.Lib/Mods/IModSource.cs
@@ -9,6 +9,10 @@ namespace Alpacka.Lib.Mods
         /// <summary> Returns if this mod source handles the specified source string. </summary>
         bool CanHandle(string source);
         
+        /// <summary> Called once before any calls to Resolve, allowing this mod
+        ///           source to initialize resources once which might take time. </summary>
+        Task Initialize();
+        
         /// <summary> Resolves as much mod information as possible before downloading
         ///           the mod, allowing for some error checking and adding dependencies.
         ///           Returns the download URL or null if the mod should be discarded. </summary>

--- a/src/Alpacka.Lib/Mods/ModSourceURL.cs
+++ b/src/Alpacka.Lib/Mods/ModSourceURL.cs
@@ -9,6 +9,9 @@ namespace Alpacka.Lib.Mods
         public bool CanHandle(string source) =>
             (source.StartsWith("http://") || source.StartsWith("https://"));
         
+        public Task Initialize() =>
+            Task.CompletedTask;
+        
         public Task<string> Resolve(EntryMod mod, string mcVersion, Action<EntryMod> addDependency) =>
             Task.FromResult(mod.Source);
     }

--- a/src/Alpacka.Lib/Mods/ModpackDownloader.cs
+++ b/src/Alpacka.Lib/Mods/ModpackDownloader.cs
@@ -47,6 +47,11 @@ namespace Alpacka.Lib.Mods
             var processing = config.Mods.Select(mod => new ModWrapper(mod.Clone(), _sources)).ToList();
             FireDownloaderExceptionIfErrored(processing, "parsing mod sources");
             
+            // Initialize used source handlers.
+            await Task.WhenAll(processing
+                .Select(mod => mod.SourceHandler).Distinct()
+                .Select(handler => handler.Initialize()));
+            
             var byName  = new Dictionary<string, ModWrapper>();
             var byModID = new Dictionary<string, ModWrapper>();
             


### PR DESCRIPTION
This allows for mod sources to initialize at a specific point in time instead of it having to be done in `Resolve`. Simplifies errors a lot because of there is an error in initialization, we don't duplicate the error times the amount of mods using that source. That is, resolving 10 mods through Curse when `AllProjects.Get` fails would've resulted in one exception thrown for each mod, not it's just one.