### PR TITLE
Review: Support LastModified / ETag

### DIFF
--- a/src/Alpacka.Lib/Net/DownloadedFile.cs
+++ b/src/Alpacka.Lib/Net/DownloadedFile.cs
@@ -1,4 +1,6 @@
+using System;
 using System.IO;
+using IOPath = System.IO.Path;
 using Newtonsoft.Json;
 
 namespace Alpacka.Lib.Net
@@ -12,16 +14,32 @@ namespace Alpacka.Lib.Net
         public string Path { get; internal set; }
         /// <summary> Original file name of the downloaded file suggested by the webserver (may be null). </summary>
         public string FileName { get; }
+        
+        /// <summary> LastModified HTTP field of the downloaded file (if any). </summary>
+        public DateTimeOffset? LastModified { get; }
+        /// <summary> HTTP ETag of the downloaded file (if any). </summary>
+        public string ETag { get; }
         /// <summary> MD5 hash of the downloaded file. </summary>
         public string MD5 { get; }
         
-        public DownloadedFile(string url, string path, string fileName, string md5)
-            { URL = url; Path = path; FileName = fileName; MD5 = md5; }
-        
-        public DownloadedFile Move(string destination, bool replace = false)
+        public DownloadedFile(string url, string path, string fileName,
+                              DateTimeOffset? lastModified, string eTag, string md5)
         {
-            if (replace && File.Exists(destination))
-                File.Delete(destination);
+            URL = url; Path = path; FileName = fileName;
+            LastModified = lastModified; ETag = eTag; MD5 = md5;
+        }
+        
+        public DownloadedFile Move(string destination)
+        {
+            var retries = 0;
+            var originalName = IOPath.GetFileNameWithoutExtension(destination);
+            while (File.Exists(destination)) {
+                if (++retries > 5) throw new IOException(
+                    $"Could not move downloaded file to '{ destination }' (gave up after 5 retries)");
+                destination = IOPath.Combine(
+                    IOPath.GetDirectoryName(destination),
+                    $"{ originalName } ({ retries }).{ IOPath.GetExtension(destination) }");
+            }
             File.Move(Path, destination);
             Path = destination;
             return this;

--- a/src/Alpacka.Lib/Net/FileDownloaderURL.cs
+++ b/src/Alpacka.Lib/Net/FileDownloaderURL.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 
@@ -38,44 +39,52 @@ namespace Alpacka.Lib.Net
         }
         
         
-        public async Task<DownloadedFile> Download(string url)
-        {
-            var response = await _client.GetAsync(url);
-            
-            int redirects = 0;
-            while ((response.StatusCode == HttpStatusCode.Moved) ||
-                   (response.StatusCode == HttpStatusCode.Redirect) ||
-                   (response.StatusCode == HttpStatusCode.TemporaryRedirect)) {
-                if (redirects++ > MAX_REDIRECTS)
-                    throw new HttpRequestException($"Too many redirects for URL '{ url }'");
-                response = await _client.GetAsync(response.Headers.Location);
-            }
-            
-            response.EnsureSuccessStatusCode();
-            
-            // Try using suggested file name or getting the it from the request uri.
-            var fileName = response.Content.Headers.ContentDisposition?.FileNameStar
-                ?? response.Content.Headers.ContentDisposition?.FileName
-                ?? GetFileNameFromUri(response.RequestMessage.RequestUri);
-            
-            if (fileName == null)
-                throw new NoFileNameException(url);
-            
-            return await _cache.Get(fileName, async () => {
+        public Task<DownloadedFile> Download(string url) =>
+            _cache.Get(url, async oldFile => {
+                
+                var request = new HttpRequestMessage(HttpMethod.Get, url);
+                if (oldFile?.ETag != null) request.Headers.IfNoneMatch.Add(new EntityTagHeaderValue(oldFile.ETag));
+                else if (oldFile?.LastModified != null) request.Headers.IfModifiedSince = oldFile.LastModified;
+                
+                var response = await _client.SendAsync(request);
+                
+                // Follow redirects. For some reason this isn't done automatically?
+                int redirects = 0;
+                while ((response.StatusCode == HttpStatusCode.Moved) ||
+                    (response.StatusCode == HttpStatusCode.Redirect) ||
+                    (response.StatusCode == HttpStatusCode.TemporaryRedirect)) {
+                    if (redirects++ > MAX_REDIRECTS)
+                        throw new HttpRequestException($"Too many redirects for URL '{ url }'");
+                    response = await _client.GetAsync(response.Headers.Location);
+                }
+                
+                // If file was not modified, return the old one.
+                if (response.StatusCode == HttpStatusCode.NotModified) {
+                    Debug.WriteLine($"Got '{ oldFile.FileName }' from cache");
+                    return oldFile;
+                }
+                
+                response.EnsureSuccessStatusCode();
+                
+                // Try using suggested file name or getting the it from the request uri.
+                var fileName = response.Content.Headers.ContentDisposition?.FileNameStar
+                    ?? response.Content.Headers.ContentDisposition?.FileName
+                    ?? GetFileNameFromUri(response.RequestMessage.RequestUri);
+                if (fileName == null) throw new NoFileNameException(url);
                 
                 var transform = new MD5Transform();
                 var tempPath  = Path.Combine(_tempDir, fileName);
                 using (var writeStream = new CryptoStream(File.OpenWrite(tempPath), transform, CryptoStreamMode.Write))
                     await response.Content.CopyToAsync(writeStream);
                 
-                var md5 = BitConverter.ToString(transform.Hash)
-                    .Replace("-", "").ToLowerInvariant();
-                
                 Debug.WriteLine($"Downloaded '{ fileName }'");
-                return new DownloadedFile(url, tempPath, fileName, md5);
+                return new DownloadedFile(url, tempPath, fileName,
+                    lastModified: response.Content.Headers.LastModified,
+                    eTag: response.Headers.ETag?.Tag,
+                    md5: BitConverter.ToString(transform.Hash)
+                        .Replace("-", "").ToLowerInvariant());
                 
             });
-        }
         
         private static string GetFileNameFromUri(Uri uri)
         {

--- a/src/Alpacka.Lib/Net/FileDownloaderURL.cs
+++ b/src/Alpacka.Lib/Net/FileDownloaderURL.cs
@@ -67,9 +67,9 @@ namespace Alpacka.Lib.Net
                 response.EnsureSuccessStatusCode();
                 
                 // Try using suggested file name or getting the it from the request uri.
-                var fileName = response.Content.Headers.ContentDisposition?.FileNameStar
-                    ?? response.Content.Headers.ContentDisposition?.FileName
-                    ?? GetFileNameFromUri(response.RequestMessage.RequestUri);
+                var fileName = response.Content.Headers.ContentDisposition?.FileNameStar.Trim('"') // Might be wrapped in quotes which
+                    ?? response.Content.Headers.ContentDisposition?.FileName.Trim('"')             // are not stripped automatically.
+                    ?? GetFileNameFromURI(response.RequestMessage.RequestUri);
                 if (fileName == null) throw new NoFileNameException(url);
                 
                 var transform = new MD5Transform();
@@ -86,11 +86,11 @@ namespace Alpacka.Lib.Net
                 
             });
         
-        private static string GetFileNameFromUri(Uri uri)
+        private static string GetFileNameFromURI(Uri uri)
         {
             try {
                 var fileName = Path.GetFileName(uri.ToString());
-                if (!fileName.EndsWith(".jar")) return null;
+                if (fileName.IndexOf('.') < 0) return null;
                 return fileName;
             } catch { return null; }
         }


### PR DESCRIPTION
Currently doesn't support multiple URLs returning the same files. I did this because if one URL were to change the contents of a file that multiple URLs currently pointed to on disk it might break things, and resolving this isn't super straight forward. I think it's not really that important.

- Update `FileDownloaderURL` and `FileCache`
- Downloader task factory now accepts old `DownloadedFile`
- Add `LastModified` and `ETag` properties to `DownloadedFile`

(This closes issue #17.)